### PR TITLE
Added Bazel build target

### DIFF
--- a/useradm/BUILD
+++ b/useradm/BUILD
@@ -1,0 +1,49 @@
+py_library(
+    name = "rbconfig",
+    srcs = ["rbconfig.py"],
+)
+
+py_library(
+    name = "rberror",
+    srcs = ["rberror.py"],
+)
+
+py_library(
+    name = "rbopt",
+    srcs = ["rbopt.py"],
+)
+
+py_library(
+    name = "rbuser",
+    srcs = ["rbuser.py"],
+)
+
+py_library(
+    name = "rbaccount",
+    srcs = ["rbaccount.py"],
+    deps = [
+        ":rbconfig",
+        ":rberror",
+        ":rbopt",
+        ":rbuser",
+    ],
+)
+
+py_library(
+    name = "rbuserdb",
+    srcs = ["rbuserdb.py"],
+    deps = [
+        ":rberror",
+        ":rbopt",
+        ":rbuser",
+    ],
+)
+
+py_binary(
+    name = "useradm",
+    srcs = ["useradm.py"],
+    deps = [
+        ":rbaccount",
+        ":rbuserdb",
+    ],
+)


### PR DESCRIPTION
Adds a build target for https://bazel.io. `pyldap` still needs to be installed using `pip`, and the structure is a bit awkward (`bazel run some/path/useradm/useradm`) but it works.

Depends on #1 to work.
